### PR TITLE
fix for tests when dbtemplates template loader is not in main settings

### DIFF
--- a/dbtemplates/tests.py
+++ b/dbtemplates/tests.py
@@ -24,6 +24,7 @@ class DbTemplatesTestCase(TestCase):
     def setUp(self):
         self.old_template_loaders = settings.TEMPLATE_LOADERS
         if 'dbtemplates.loader.Loader' not in settings.TEMPLATE_LOADERS:
+            loader.template_source_loaders = None
             settings.TEMPLATE_LOADERS = (list(settings.TEMPLATE_LOADERS) +
                                          ['dbtemplates.loader.Loader'])
 
@@ -38,6 +39,7 @@ class DbTemplatesTestCase(TestCase):
         self.t2.sites.add(self.site2)
 
     def tearDown(self):
+        loader.template_source_loaders = None
         settings.TEMPLATE_LOADERS = self.old_template_loaders
 
     def test_basiscs(self):


### PR DESCRIPTION
TEMPLATE_LOADERS are cached, so tests need to invalidate this cache if they change this settings (as per https://code.djangoproject.com/ticket/1292 )

This commit fixes this. I'm testing on django 1.3.1
