### PR TITLE
Fixed an issue where ``get_cache_key`` may produce invalid memcached keys

### DIFF
--- a/dbtemplates/tests.py
+++ b/dbtemplates/tests.py
@@ -14,7 +14,7 @@ from django.contrib.sites.models import Site
 
 from dbtemplates.conf import settings
 from dbtemplates.models import Template
-from dbtemplates.utils.cache import get_cache_backend
+from dbtemplates.utils.cache import get_cache_backend, get_cache_key
 from dbtemplates.utils.template import (get_template_source,
                                         check_template_syntax)
 from dbtemplates.management.commands.sync_templates import (FILES_TO_DATABASE,
@@ -142,3 +142,7 @@ class DbTemplatesTestCase(TestCase):
             name='good.html', content='{% if foo %}Bar{% endif %}')
         self.assertFalse(check_template_syntax(bad_template)[0])
         self.assertTrue(check_template_syntax(good_template)[0])
+
+    def test_get_cache_name(self):
+        name = 'name with spaces'
+        self.assertEqual(get_cache_key(name), 'dbtemplates::name-with-spaces::1')

--- a/dbtemplates/utils/cache.py
+++ b/dbtemplates/utils/cache.py
@@ -1,6 +1,7 @@
 from django.core.cache import get_cache
 
 from django.contrib.sites.models import Site
+from django.template.defaultfilters import slugify
 
 from dbtemplates.conf import settings
 
@@ -13,7 +14,7 @@ cache = get_cache_backend()
 
 def get_cache_key(name):
     current_site = Site.objects.get_current()
-    return 'dbtemplates::%s::%s' % (name, current_site.pk)
+    return 'dbtemplates::%s::%s' % (slugify(name), current_site.pk)
 
 
 def get_cache_notfound_key(name):


### PR DESCRIPTION
Hi Jannis,

I'm using dbtemplates with johnny cache and it causes johnny's `CACHE_BACKEND` to complain on template names containing spaces.

This commit fixes the issue.

Thanks,
Selwin
