### PR TITLE
Fix link to django-reversion doc.

### DIFF
--- a/docs/advanced.txt
+++ b/docs/advanced.txt
@@ -62,7 +62,7 @@ Short installation howto
 4. Set ``DBTEMPLATES_USE_REVERSION`` setting to ``True``
 
 .. _django-reversion: https://github.com/etianen/django-reversion
-.. _django-reversion's documentation: https://github.com/etianen/django-reversion/wiki/getting-started
+.. _django-reversion's documentation: http://django-reversion.readthedocs.org/en/latest/
 
 .. _commands:
 


### PR DESCRIPTION
Fix URL of _django-reversion_'s documentation. Apparently, it uses ReadTheDocs instead of GitHub's wiki now.
