### PR TITLE
Remove Django 1.9 importlib warning

### DIFF
--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -1,7 +1,7 @@
 from django import VERSION
 from django.template import (Template, TemplateDoesNotExist,
                              TemplateSyntaxError)
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def get_loaders():

--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -1,7 +1,10 @@
 from django import VERSION
 from django.template import (Template, TemplateDoesNotExist,
                              TemplateSyntaxError)
-from importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 def get_loaders():


### PR DESCRIPTION
The warning says: `RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.`