### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ django-dbtemplates
 It also features optional support for versioned storage and django-admin
 command, integrates with Django's caching system and the admin actions.
 
-Please see http://django-dbtemplates.readthedocs.org/ for more details.
+Please see https://django-dbtemplates.readthedocs.io/ for more details.
 
 The source code and issue tracker can be found on Github:
 

--- a/docs/advanced.txt
+++ b/docs/advanced.txt
@@ -62,7 +62,7 @@ Short installation howto
 4. Set ``DBTEMPLATES_USE_REVERSION`` setting to ``True``
 
 .. _django-reversion: https://github.com/etianen/django-reversion
-.. _django-reversion's documentation: http://django-reversion.readthedocs.org/en/latest/
+.. _django-reversion's documentation: https://django-reversion.readthedocs.io/en/latest/
 
 .. _commands:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,7 +41,7 @@ v1.3 (2012-05-07)
 * Moved test runner to use nose_ and a hosted CI project at Travis_:
   http://travis-ci.org/jazzband/django-dbtemplates
 
-.. _nose: http://nose.rtfd.org/
+.. _nose: https://nose.readthedocs.io/
 .. _Travis: http://travis-ci.org
 
 v1.2.1 (2011-09-07)

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -11,7 +11,7 @@ It also features optional support for :ref:`versioned storage <versioned>`
 and :ref:`django-admin command <commands>`, integrates with Django's
 :ref:`caching system <caching>` and the :ref:`admin actions <admin_actions>`.
 
-Please see http://django-dbtemplates.readthedocs.org/ for more details.
+Please see https://django-dbtemplates.readthedocs.io/ for more details.
 
 The source code and issue tracker can be found on Github: https://github.com/jazzband/django-dbtemplates
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=read('README.rst'),
     author='Jannis Leidel',
     author_email='jannis@leidel.info',
-    url='http://django-dbtemplates.readthedocs.org/',
+    url='https://django-dbtemplates.readthedocs.io/',
     packages=find_packages(exclude=['example']),
     zip_safe=False,
     package_data={


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.