### PR TITLE
fixed method call with named argument

### DIFF
--- a/dbtemplates/admin.py
+++ b/dbtemplates/admin.py
@@ -80,7 +80,7 @@ class TemplateAdminForm(forms.ModelForm):
     Custom AdminForm to make the content textarea wider.
     """
     content = forms.CharField(
-        widget=TemplateContentTextArea({'rows': '24'}),
+        widget=TemplateContentTextArea(attrs={'rows': '24'}),
         help_text=content_help_text, required=False)
 
     class Meta:


### PR DESCRIPTION
Use of the named parameter attrs.
Without it was giving me an error using TinyMCE because the first parameter of the TinyMCE Widget is content_language ( see : https://github.com/aljosa/django-tinymce/blob/master/tinymce/widgets.py )
```

class TinyMCE(forms.Textarea):
    def __init__(self, content_language=None, attrs=None, mce_attrs=None):
        super(TinyMCE, self).__init__(attrs)
```

File "/usr/local/lib/python2.7/dist-packages/tinymce/widgets.py", line 123, in get_language_config
    content_language = content_language[:2]
TypeError: unhashable type

content of content_language is {'rows': '24'}, which should be the parameter attrs and not content_language