### PR TITLE
Add support for Django2.0, drop 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+- '3.7'
 sudo: false
 cache: pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-- '3.7'
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+# See https://github.com/travis-ci/travis-ci/issues/9815
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 sudo: false
 cache: pip
 install:

--- a/dbtemplates/admin.py
+++ b/dbtemplates/admin.py
@@ -29,7 +29,7 @@ class CodeMirrorTextArea(forms.Textarea):
             settings.DBTEMPLATES_MEDIA_PREFIX, 'css/editor.css')])
         js = [posixpath.join(settings.DBTEMPLATES_MEDIA_PREFIX, 'js/codemirror.js')]
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         result = []
         result.append(
             super(CodeMirrorTextArea, self).render(name, value, attrs))

--- a/dbtemplates/test_cases.py
+++ b/dbtemplates/test_cases.py
@@ -42,7 +42,7 @@ class DbTemplatesTestCase(TestCase):
         loader.template_source_loaders = None
         settings.TEMPLATE_LOADERS = self.old_template_loaders
 
-    def test_basiscs(self):
+    def test_basics(self):
         self.assertEqual(list(self.t1.sites.all()), [self.site1])
         self.assertTrue("base" in self.t1.content)
         self.assertEqual(list(Template.objects.filter(sites=self.site1)),

--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -1,6 +1,5 @@
 from django.template import (Template, TemplateDoesNotExist,
                              TemplateSyntaxError)
-from importlib import import_module
 
 
 def get_loaders():
@@ -17,20 +16,13 @@ def get_template_source(name):
         if loader.__module__.startswith('dbtemplates.'):
             # Don't give a damn about dbtemplates' own loader.
             continue
-        module = import_module(loader.__module__)
-        load_template_source = getattr(
-            module, 'load_template_source', None)
-        if load_template_source is None:
-            load_template_source = loader.load_template_source
-        try:
-            source, origin = load_template_source(name)
+        for origin in loader.get_template_sources(name):
+            try:
+                source = loader.get_contents(origin)
+            except (NotImplementedError, TemplateDoesNotExist):
+                continue
             if source:
                 return source
-        except NotImplementedError:
-            pass
-        except TemplateDoesNotExist:
-            pass
-    return None
 
 
 def check_template_syntax(template):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     flake8-py27,
     flake8-py35,
     readme-py27,
-    py{27,34,35}-dj{18,19,110}
+    py{27,34,35}-dj{19,110}
     py{27,34,35,36}-dj111
     py{34,35,36}-dj20
 
@@ -21,7 +21,6 @@ setenv =
     DJANGO_SETTINGS_MODULE = dbtemplates.test_settings
 deps =
     -rrequirements/tests.txt
-    dj18: Django<1.9
     dj19: Django<1.10
     dj110: Django<1.11
     dj111: Django<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@ usedevelop = True
 minversion = 1.8
 envlist =
     flake8-py27,
-    flake8-py35,
+    flake8-py37,
     readme-py27,
-    py{27,34,35}-dj{19,110}
+    readme-py37,
     py{27,34,35,36}-dj111
-    py{34,35,36}-dj20
+    py{34,35,36,37}-dj20
+    py{34,35,36,37}-dj21
 
 [testenv]
 basepython =
@@ -16,15 +17,15 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 usedevelop = true
 setenv =
     DJANGO_SETTINGS_MODULE = dbtemplates.test_settings
 deps =
-    -rrequirements/tests.txt
-    dj19: Django<1.10
-    dj110: Django<1.11
+    -r requirements/tests.txt
     dj111: Django<2.0
     dj20: Django<2.1
+    dj21: Django<2.2
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 
 commands =
@@ -36,11 +37,15 @@ commands =
 commands = python setup.py check -r -s
 deps = readme_renderer
 
+[testenv:readme-py37]
+commands = python setup.py check -r -s
+deps = readme_renderer
+
 [testenv:flake8-py27]
 commands = flake8 dbtemplates
 deps = flake8
 
-[testenv:flake8-py35]
+[testenv:flake8-py37]
 commands = flake8 dbtemplates
 deps = flake8
 


### PR DESCRIPTION
**Problem**
App does not work with Django 2.0 (tests are failing)

**Cause**
`load_template_sources` method is deprecated in Django 1.9 and removed in Django2.0:
see https://docs.djangoproject.com/en/1.9/releases/1.9/#template-loader-apis-have-changed

**Solution**
This PR adds support for new template API , thus making app compatible with Django1.9+ (1.8 dropped as it would be cumbersome to support two versions of template API )


In fact, in https://docs.djangoproject.com/en/2.0/releases/2.0/#third-party-library-support-for-older-version-of-django they even say:
>Following the release of Django 2.0, we suggest that third-party app authors drop support for all versions of Django prior to 1.11

But tests with 1.9 and 1.10 seems to be passing, so no need to drop them right now.