### PR TITLE
Fix bytes string migration (python3)

### DIFF
--- a/dbtemplates/migrations/0001_initial.py
+++ b/dbtemplates/migrations/0001_initial.py
@@ -37,8 +37,7 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
             managers=[
                 ('objects', django.db.models.manager.Manager()),
-                ('on_site', django.contrib.sites.managers.CurrentSiteManager(
-                    b'sites')),
+                ('on_site', django.contrib.sites.managers.CurrentSiteManager('sites')),
             ],
         ),
     ]


### PR DESCRIPTION
Hello,

What I think is a typo corrupts the migration file and makes Django think that the migration system is out of sync. Here is the symptom I have:

```bash
Your models have changes that are not yet reflected in a migration, and so won't be applied.
  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
```

And when I run `./manage.py makemigrations` here is the output:
```bash
2018-02-12 19:05:45,821 INFO [registration:70] REGISTER <class 'houseofgigs.models.company.Company'>
Migrations for 'dbtemplates':
  env/lib/python3.6/site-packages/dbtemplates/migrations/0002_auto_20180212_1905.py
    - Change managers on template
```
And the generated file:
```python
# -*- coding: utf-8 -*-
# Generated by Django 1.11.5 on 2018-02-12 19:05
from __future__ import unicode_literals

import django.contrib.sites.managers
from django.db import migrations
import django.db.models.manager


class Migration(migrations.Migration):

    dependencies = [
        ('dbtemplates', '0001_initial'),
    ]

    operations = [
        migrations.AlterModelManagers(
            name='template',
            managers=[
                ('objects', django.db.models.manager.Manager()),
                ('on_site', django.contrib.sites.managers.CurrentSiteManager('sites')),
            ],
        ),
    ]
```

This pull request is an attempt to fix this :)