### PR TITLE
Fix Template string representation for python3

### DIFF
--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -8,12 +8,12 @@ from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models import signals
 from django.template import TemplateDoesNotExist
+from django.utils.six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import now
-import six
 
 
-@six.python_2_unicode_compatible
+@python_2_unicode_compatible
 class Template(models.Model):
     """
     Defines a template model for use with the database template loader.

--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -10,8 +10,10 @@ from django.db.models import signals
 from django.template import TemplateDoesNotExist
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import now
+import six
 
 
+@six.python_2_unicode_compatible
 class Template(models.Model):
     """
     Defines a template model for use with the database template loader.
@@ -36,7 +38,7 @@ class Template(models.Model):
         verbose_name_plural = _('templates')
         ordering = ('name',)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def populate(self, name=None):


### PR DESCRIPTION
Hello,

I realized that there was an issue with `Template.__str__`. Indeed it was only working on python2. This pull request is an attempt to fix that.