### PR TITLE
Feature proposal: title and category fields

### DIFF
--- a/dbtemplates/admin.py
+++ b/dbtemplates/admin.py
@@ -86,7 +86,6 @@ class TemplateAdminForm(forms.ModelForm):
 
     class Meta:
         model = Template
-        fields = ('name', 'content', 'sites', 'creation_date', 'last_changed')
         fields = "__all__"
 
 
@@ -94,7 +93,7 @@ class TemplateAdmin(TemplateModelAdmin):
     form = TemplateAdminForm
     fieldsets = (
         (None, {
-            'fields': ('name', 'content'),
+            'fields': ('title', 'category', 'name', 'content'),
             'classes': ('monospace',),
         }),
         (_('Advanced'), {
@@ -106,10 +105,10 @@ class TemplateAdmin(TemplateModelAdmin):
         }),
     )
     filter_horizontal = ('sites',)
-    list_display = ('name', 'creation_date', 'last_changed', 'site_list')
-    list_filter = ('sites',)
+    list_display = ('__str__', 'creation_date', 'last_changed', 'category', 'site_list')
+    list_filter = ('sites', 'category')
     save_as = True
-    search_fields = ('name', 'content')
+    search_fields = ('name', 'title', 'content')
     actions = ['invalidate_cache', 'repopulate_cache', 'check_syntax']
 
     def invalidate_cache(self, request, queryset):

--- a/dbtemplates/migrations/0002_auto_20180703_0742.py
+++ b/dbtemplates/migrations/0002_auto_20180703_0742.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dbtemplates', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='template',
+            name='category',
+            field=models.CharField(
+                help_text=(
+                    'The category for this template, useful '
+                    'if you want to organize your templates.'
+                ),
+                max_length=50, verbose_name='category', default=b'', blank=True
+            ),
+        ),
+        migrations.AddField(
+            model_name='template',
+            name='title',
+            field=models.CharField(
+                help_text='The title of this template, used for display only.',
+                max_length=100, verbose_name='title', default=b'', blank=True
+            ),
+        ),
+    ]

--- a/dbtemplates/migrations/0002_auto_20180703_0742.py
+++ b/dbtemplates/migrations/0002_auto_20180703_0742.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                     'The category for this template, useful '
                     'if you want to organize your templates.'
                 ),
-                max_length=50, verbose_name='category', default=b'', blank=True
+                max_length=50, verbose_name='category', default='', blank=True
             ),
         ),
         migrations.AddField(
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             name='title',
             field=models.CharField(
                 help_text='The title of this template, used for display only.',
-                max_length=100, verbose_name='title', default=b'', blank=True
+                max_length=100, verbose_name='title', default='', blank=True
             ),
         ),
     ]

--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -48,7 +48,7 @@ class Template(models.Model):
         ordering = ('name',)
 
     def __unicode__(self):
-        return self.name
+        return self.title or self.name
 
     def populate(self, name=None):
         """

--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -19,6 +19,17 @@ class Template(models.Model):
     """
     name = models.CharField(_('name'), max_length=100,
                             help_text=_("Example: 'flatpages/default.html'"))
+    title = models.CharField(
+        _('title'), max_length=100, default='', blank=True,
+        help_text=_("The title of this template, used for display only.")
+    )
+    category = models.CharField(
+        _('category'), max_length=50, default='', blank=True,
+        help_text=_(
+            "The category for this template, "
+            "useful if you want to organize your templates."
+        )
+    )
     content = models.TextField(_('content'), blank=True)
     sites = models.ManyToManyField(Site, verbose_name=_(u'sites'),
                                    blank=True)


### PR DESCRIPTION
Hi there,

This Pull Request is a feature proposal. In my project, I felt the need to:
- add a human-readable `title` to the `Template` model: I don't mind reading file names, but my teammates are less tech-savvy than me (i.e. they are not devs). I think it could be interesting for other people too
- add an arbirtrary `category` to the `Template` model: I needed that in order to organize templates a little bit better. You can filter using this field in the admin, and you can use it in the backend if you want to restrict the use to other templates

LMK if this is something you would like to merge.

N.B.: I know that some of the tests are failing, but there are [a bunch of PRs](https://github.com/jazzband/django-dbtemplates/pulls) that need to be merged in master before I can fix them.