### PR TITLE
Django 3.0.4

### DIFF
--- a/dbtemplates/conf.py
+++ b/dbtemplates/conf.py
@@ -2,7 +2,7 @@ import posixpath
 
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
-from django.utils.six import string_types
+from six import string_types
 
 from appconf import AppConf
 

--- a/dbtemplates/management/commands/sync_templates.py
+++ b/dbtemplates/management/commands/sync_templates.py
@@ -5,12 +5,12 @@ from django.contrib.sites.models import Site
 from django.core.management.base import CommandError, BaseCommand
 from django.template.utils import get_app_template_dirs
 from django.template.loader import _engine_list
+try:
+    from six import input
+except ImportError:
+    pass
 
 from dbtemplates.models import Template
-
-# (propably obsolete) backwards compatability as django already threw out six
-if sys.version_info[0] == 2:
-    input = raw_input  # noqa: F821
 
 ALWAYS_ASK, FILES_TO_DATABASE, DATABASE_TO_FILES = ('0', '1', '2')
 

--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -8,7 +8,7 @@ from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models import signals
 from django.template import TemplateDoesNotExist
-from django.utils.six import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import now
 

--- a/dbtemplates/test_cases.py
+++ b/dbtemplates/test_cases.py
@@ -22,10 +22,10 @@ from dbtemplates.management.commands.sync_templates import (FILES_TO_DATABASE,
 
 class DbTemplatesTestCase(TestCase):
     def setUp(self):
-        self.old_template_loaders = settings.TEMPLATE_LOADERS
-        if 'dbtemplates.loader.Loader' not in settings.TEMPLATE_LOADERS:
+        self.old_TEMPLATES = settings.TEMPLATES
+        if 'dbtemplates.loader.Loader' not in settings.TEMPLATES:
             loader.template_source_loaders = None
-            settings.TEMPLATE_LOADERS = list(settings.TEMPLATE_LOADERS) + [
+            settings.TEMPLATES = list(settings.TEMPLATES) + [
                 'dbtemplates.loader.Loader'
             ]
 
@@ -41,7 +41,7 @@ class DbTemplatesTestCase(TestCase):
 
     def tearDown(self):
         loader.template_source_loaders = None
-        settings.TEMPLATE_LOADERS = self.old_template_loaders
+        settings.TEMPLATES = self.old_TEMPLATES
 
     def test_basics(self):
         self.assertEqual(list(self.t1.sites.all()), [self.site1])

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Framework :: Django',
     ],
-    install_requires=['django-appconf >= 0.4'],
+    install_requires=['django-appconf >= 0.4', 'six'],
 )


### PR DESCRIPTION
Replaced django.utils.six with six, and TEMPLATE_LOADERS with TEMPLATES. 
Could use a refactor to eliminate the unicode_compatibility code. 