### PR TITLE
Update cache.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.*
+!.gitignore
+!.coveragerc
 *.pyc
 .*.swp
 MANIFEST

--- a/dbtemplates/management/commands/sync_templates.py
+++ b/dbtemplates/management/commands/sync_templates.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
                 for f in [f for f in filenames
                           if f.endswith(extension) and not f.startswith(".")]:
                     path = os.path.join(dirpath, f)
-                    name = path.split(templatedir)[1]
+                    name = path.split(str(templatedir))[1]
                     if name.startswith('/'):
                         name = name[1:]
                     try:

--- a/dbtemplates/utils/cache.py
+++ b/dbtemplates/utils/cache.py
@@ -9,8 +9,12 @@ def get_cache_backend():
     """
     Compatibilty wrapper for getting Django's cache backend instance
     """
-    from django.core.cache import _create_cache
-    cache = _create_cache(settings.DBTEMPLATES_CACHE_BACKEND)
+    if django.VERSION[0] >= 3 and django.VERSION[1] >= 2:
+        from django.core.cache import caches
+        cache = caches.create_connection(settings.DBTEMPLATES_CACHE_BACKEND)
+    else:
+        from django.core.cache import _create_cache
+        cache = _create_cache(settings.DBTEMPLATES_CACHE_BACKEND)
     # Some caches -- python-memcached in particular -- need to do a cleanup at
     # the end of a request cycle. If not implemented in a particular backend
     # cache.close is a no-op

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py{35,36}-dj111
     py{35,36,37}-dj21
     py{35,36,37,38,39}-dj22
+    py{36,37,38,39}-dj{30,31}
 
 [gh-actions]
 python =
@@ -32,6 +33,8 @@ deps =
     dj20: Django<2.1
     dj21: Django<2.2
     dj22: Django<2.3
+    dj30: Django<3.1
+    dj31: Django<3.2
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =


### PR DESCRIPTION
add support for django 3.2 new cache handling without dropping support for older django versions