### PR TITLE
Django 3.2 compatibility

### DIFF
--- a/dbtemplates/management/commands/sync_templates.py
+++ b/dbtemplates/management/commands/sync_templates.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             tpl_dirs = app_template_dirs + DIRS
         else:
             tpl_dirs = DIRS + app_template_dirs
-        templatedirs = [d for d in tpl_dirs if os.path.isdir(d)]
+        templatedirs = [str(d) for d in tpl_dirs if os.path.isdir(d)]
 
         for templatedir in templatedirs:
             for dirpath, subdirs, filenames in os.walk(templatedir):

--- a/dbtemplates/utils/cache.py
+++ b/dbtemplates/utils/cache.py
@@ -1,3 +1,4 @@
+import django
 from django.core import signals
 from django.contrib.sites.models import Site
 from django.template.defaultfilters import slugify
@@ -9,8 +10,12 @@ def get_cache_backend():
     """
     Compatibilty wrapper for getting Django's cache backend instance
     """
-    from django.core.cache import _create_cache
-    cache = _create_cache(settings.DBTEMPLATES_CACHE_BACKEND)
+    if django.VERSION[0] >= 3 and django.VERSION[1] >= 2:
+        from django.core.cache import caches
+        cache = caches.create_connection(settings.DBTEMPLATES_CACHE_BACKEND)
+    else:
+        from django.core.cache import _create_cache
+        cache = _create_cache(settings.DBTEMPLATES_CACHE_BACKEND)
     # Some caches -- python-memcached in particular -- need to do a cleanup at
     # the end of a request cycle. If not implemented in a particular backend
     # cache.close is a no-op

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     dj22: Django<2.3
     dj30: Django<3.1
     dj31: Django<3.2
+    dj32: Django<3.3
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,11 @@ usedevelop = True
 minversion = 1.8
 envlist =
     flake8
-    py{35,36}-dj111
-    py{35,36,37}-dj21
-    py{35,36,37,38,39}-dj22
-    py{36,37,38,39}-dj{30,31}
+    py3{6,7,8,9}-dj22
+    py3{6,7,8,9}-dj32
 
 [gh-actions]
 python =
-    3.5: py36
     3.6: py36
     3.7: py37
     3.8: py38, flake8
@@ -19,7 +16,6 @@ python =
 
 [testenv]
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
@@ -29,12 +25,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = dbtemplates.test_settings
 deps =
     -r requirements/tests.txt
-    dj111: Django<2.0
-    dj20: Django<2.1
-    dj21: Django<2.2
     dj22: Django<2.3
-    dj30: Django<3.1
-    dj31: Django<3.2
     dj32: Django<3.3
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
@@ -45,7 +36,7 @@ commands =
     coverage xml
 
 [testenv:flake8]
-basepython = python3.8
+basepython = python3.9
 commands = flake8 dbtemplates
 deps = flake8
 


### PR DESCRIPTION
All tests pass for Django==3.2.

Changes include:
- Using `caches.create_connection` to access cache
- Cast PosixPath to str in `sync_templates`

[#116]