### PR TITLE
Add install_requires: "Django >= 3.3"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
         "Framework :: Django",
     ],
     python_requires=">=3.7",
-    install_requires=["django-appconf >= 0.4"],
+    install_requires=[
+        "django-appconf >= 0.4",
+        "Django >= 3.3",
+    ],
 )
 


### PR DESCRIPTION
According to the ChangeLog support for 3.2 was removed.