### PR TITLE
Add an explicit id AutoField

### DIFF
--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -19,6 +19,8 @@ class Template(models.Model):
     Defines a template model for use with the database template loader.
     The field ``name`` is the equivalent to the filename of a static template.
     """
+    id = models.AutoField(primary_key=True, verbose_name=_('ID'),
+                          serialize=False, auto_created=True)
     name = models.CharField(_('name'), max_length=100,
                             help_text=_("Example: 'flatpages/default.html'"))
     content = models.TextField(_('content'), blank=True)


### PR DESCRIPTION
If a Django application uses the setting `DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'`, Django will suggest generating the migration `0002_alter_template_id`, which changes the field type of `Template.id`.

Creating your own migration in the package is not a good idea, as if an official migration 0002 appears in the future, it will cause a conflict. To avoid this, I've added an explicit `id` field of type `AutoField`, maintaining backward compatibility and preventing Django from generating a new migration.