### PR TITLE
Support for Python 3.12 and up

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ source = dbtemplates
 branch = 1
 
 [report]
-omit = *tests*,*migrations*
+omit = *tests*,*/migrations/*,test_*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.13']
 
     steps:
     - uses: actions/checkout@v3

--- a/dbtemplates/__init__.py
+++ b/dbtemplates/__init__.py
@@ -1,10 +1,3 @@
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 
-try:
-    __version__ = get_distribution("django-dbtemplates").version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = None
-
-
-default_app_config = 'dbtemplates.apps.DBTemplatesConfig'
+__version__ = importlib.metadata.version("django-dbtemplates")

--- a/dbtemplates/admin.py
+++ b/dbtemplates/admin.py
@@ -2,15 +2,8 @@ import posixpath
 from django import forms
 from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
-try:
-    # Django 4.0
-    from django.utils.translation import gettext_lazy as _
-    from django.utils.translation import ngettext
-except ImportError:
-    # Before Django 4.0
-    from django.utils.translation import ugettext_lazy as _
-    from django.utils.translation import ungettext as ngettext
-
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 from django.utils.safestring import mark_safe
 
 from dbtemplates.conf import settings

--- a/dbtemplates/apps.py
+++ b/dbtemplates/apps.py
@@ -1,8 +1,5 @@
 from django.apps import AppConfig
-try:
-    from django.utils.translation import ugettext_lazy as _
-except ImportError:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DBTemplatesConfig(AppConfig):

--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -1,19 +1,16 @@
 from dbtemplates.conf import settings
-from dbtemplates.utils.cache import (add_template_to_cache,
-                                     remove_cached_template)
+from dbtemplates.utils.cache import (
+    add_template_to_cache,
+    remove_cached_template,
+)
 from dbtemplates.utils.template import get_template_source
+
 from django.contrib.sites.managers import CurrentSiteManager
 from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models import signals
 from django.template import TemplateDoesNotExist
-try:
-    # Django >= 4.0
-    from django.utils.translation import gettext_lazy as _
-except ImportError:
-    # Django 3.2
-    from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import now
 
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,7 +1,20 @@
 Changelog
 =========
 
-v4.0 (unreleased)
+v5.0 (unreleased)
+-----------------
+
+.. warning::
+
+  This is a backwards-incompatible release!
+
+* Dropped support for Python 3.7 and Django < 4.2.
+
+* Added support for Python 3.11, 3.12, 3.13.
+
+* Django 5.x support
+
+v4.0 (2022-09-3)
 -----------------
 
 .. warning::

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import io
 from setuptools import setup, find_packages
 
 
@@ -36,13 +35,15 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Django",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=["django-appconf >= 0.4"],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ python =
     3.10: py310, flake8
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 skipsdist = true
@@ -25,6 +26,7 @@ basepython =
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 setenv =
     DJANGO_SETTINGS_MODULE = dbtemplates.test_settings
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,36 @@
 [tox]
-skipsdist = True
-usedevelop = True
-minversion = 1.8
+minversion = 4.0
 envlist =
     flake8
-    py3{7,8,9,10,11}-dj32
-    py3{8,9,10,11}-dj{40,41,main}
+    py3{8,9,10,11,12}-dj42
+    py3{10,11,12}-dj{50}
+    py3{10,11,12,13}-dj{51,main}
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.10: py310, flake8
     3.11: py311
+    3.12: py312
 
 [testenv]
+skipsdist = true
+package = editable
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
-usedevelop = true
+    py312: python3.12
 setenv =
     DJANGO_SETTINGS_MODULE = dbtemplates.test_settings
 deps =
     -r requirements/tests.txt
-    dj32: Django<3.3
-    dj40: Django<4.1
-    dj41: Django<4.2
+    dj42: Django<4.3
+    dj50: Django<5.1
+    dj51: Django<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     flake8
     py3{8,9,10,11,12}-dj42
     py3{10,11,12}-dj{50}
-    py3{10,11,12,13}-dj{51,main}
+    py3{10,11,12,13}-dj{51,52}
+    py3{12,13}-dj{main}
 
 [gh-actions]
 python =
@@ -31,10 +32,13 @@ deps =
     dj42: Django<4.3
     dj50: Django<5.1
     dj51: Django<5.2
+    # TODO change this afte Django 5.2 is out
+    dj52: Django==5.2a1
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =
     python --version
+    python -c "import django ; print(django.VERSION)"
     coverage run {envbindir}/django-admin test -v2 {posargs:dbtemplates}
     coverage report
     coverage xml


### PR DESCRIPTION
- removed deprecated pkg_resources (required for Python 3.12 and up)
- updated testing matrix to drop older Django and Python versions and also added the newer ones
- fixed tox.ini so tests should be running now
- removed ugettext calls, they have been deprecated since 3.2 and thats the lowest supported version
- changed coveragerc so the test files and migrations are not included


Also fixes https://github.com/jazzband/django-dbtemplates/issues/141 and https://github.com/jazzband/django-dbtemplates/issues/129