### PR TITLE
Make creation_date and last_updated fields readonly in admin 

### DIFF
--- a/dbtemplates/admin.py
+++ b/dbtemplates/admin.py
@@ -97,6 +97,7 @@ class TemplateAdminForm(forms.ModelForm):
 
 class TemplateAdmin(TemplateModelAdmin):
     form = TemplateAdminForm
+    readonly_fields = ['creation_date', 'last_changed']
     fieldsets = (
         (None, {
             'fields': ('name', 'content'),


### PR DESCRIPTION
These fields are automatically updated by Django when the model is saved, so there's probably no need to make them editable in the admin.