### PR TITLE
Add default_auto_field to AppConfig

### DIFF
--- a/dbtemplates/apps.py
+++ b/dbtemplates/apps.py
@@ -5,3 +5,5 @@ from django.utils.translation import gettext_lazy as _
 class DBTemplatesConfig(AppConfig):
     name = 'dbtemplates'
     verbose_name = _('Database templates')
+
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Alternative to #142.

This adds `default_auto_field` to this AppConfig, which follows Django's intention a bit more.

I have verified that this does not cause Django to create any additional migrations.