### PR TITLE
Cleanup: Properly add Django 5.2 and tweak coverage collection

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py3{10,11,12}-dj{50}
     py3{10,11,12,13}-dj{51,52}
     py3{12,13}-dj{main}
+    coverage
 
 [gh-actions]
 python =
@@ -31,17 +32,22 @@ setenv =
     DJANGO_SETTINGS_MODULE = dbtemplates.test_settings
 deps =
     -r requirements/tests.txt
-    dj42: Django<4.3
-    dj50: Django<5.1
-    dj51: Django<5.2
-    # TODO change this afte Django 5.2 is out
-    dj52: Django==5.2a1
+    dj42: Django>=4.2,<4.3
+    dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<5.3
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =
     python --version
     python -c "import django ; print(django.VERSION)"
-    coverage run {envbindir}/django-admin test -v2 {posargs:dbtemplates}
+    coverage run --branch --parallel-mode {envbindir}/django-admin test -v2 {posargs:dbtemplates}
+
+[testenv:coverage]
+basepython = python3.10
+deps = coverage
+commands =
+    coverage combine
     coverage report
     coverage xml
 


### PR DESCRIPTION
The `--parallel-mode` option to `coverage` will cause it to create a bunch of separate coverage logs when run locally via tox.

But in GHA, they should still all be picked up by the Codecov action.