### PR TITLE
Bugfix: Set templatized related_name and related_query_name in AbstractTemplateMixin

### DIFF
--- a/dbtemplates/migrations/0001_initial.py
+++ b/dbtemplates/migrations/0001_initial.py
@@ -51,7 +51,8 @@ class Migration(migrations.Migration):
                 (
                     "sites",
                     models.ManyToManyField(
-                        to="sites.Site", verbose_name="sites", blank=True
+                        to="sites.Site", verbose_name="sites", blank=True,
+                        related_name='%(class)s_set', related_query_name='%(class)s',
                     ),
                 ),
             ],

--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -23,8 +23,10 @@ class AbstractTemplateMixin(models.Model):
     name = models.CharField(_('name'), max_length=100,
                             help_text=_("Example: 'flatpages/default.html'"))
     content = models.TextField(_('content'), blank=True)
-    sites = models.ManyToManyField(Site, verbose_name=_('sites'),
-                                   blank=True)
+    sites = models.ManyToManyField(
+        Site, verbose_name=_('sites'), blank=True,
+        related_name='%(class)s_set', related_query_name='%(class)s',
+    )
     creation_date = models.DateTimeField(_('creation date'), auto_now_add=True)
     last_changed = models.DateTimeField(_('last changed'), auto_now=True)
 


### PR DESCRIPTION
Forgot to do this in #150.

I picked reverse compatible related names even though it's more typical to use `%(app_label)s_%(class)ss`. However, this means that any subclasses will not be able to be called `Template` even if they are in a different app. I think that's a reasonable tradeoff.

Fixes this error:
```
ERRORS:
dbtemplates.Template.sites: (fields.E304) Reverse accessor 'Site.template_set' for 'dbtemplates.Template.sites' clashes with reverse accessor for 'myapp.Template.sites'.
	HINT: Add or change a related_name argument to the definition for 'dbtemplates.Template.sites' or 'myapp.Template.sites'.
dbtemplates.Template.sites: (fields.E305) Reverse query name for 'dbtemplates.Template.sites' clashes with reverse query name for 'myapp.Template.sites'.
	HINT: Add or change a related_name argument to the definition for 'dbtemplates.Template.sites' or 'myapp.Template.sites'.
myapp.Template.sites: (fields.E304) Reverse accessor 'Site.template_set' for 'myapp.Template.sites' clashes with reverse accessor for 'dbtemplates.Template.sites'.
	HINT: Add or change a related_name argument to the definition for 'myapp.Template.sites' or 'dbtemplates.Template.sites'.
myapp.Template.sites: (fields.E305) Reverse query name for 'myapp.Template.sites' clashes with reverse query name for 'dbtemplates.Template.sites'.
	HINT: Add or change a related_name argument to the definition for 'myapp.Template.sites' or 'dbtemplates.Template.sites'.
```