### PR TITLE
Revert "Split out an AbstractTemplate model for easier reuse"

### DIFF
--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -13,7 +13,7 @@ from django.template import TemplateDoesNotExist
 from django.utils.translation import gettext_lazy as _
 
 
-class AbstractTemplateMixin(models.Model):
+class Template(models.Model):
     """
     Defines a template model for use with the database template loader.
     The field ``name`` is the equivalent to the filename of a static template.
@@ -32,7 +32,7 @@ class AbstractTemplateMixin(models.Model):
     on_site = CurrentSiteManager('sites')
 
     class Meta:
-        abstract = True
+        db_table = 'django_template'
         verbose_name = _('template')
         verbose_name_plural = _('templates')
         ordering = ('name',)
@@ -60,13 +60,6 @@ class AbstractTemplateMixin(models.Model):
         if settings.DBTEMPLATES_AUTO_POPULATE_CONTENT and not self.content:
             self.populate()
         super().save(*args, **kwargs)
-
-
-class Template(AbstractTemplateMixin, models.Model):
-    class Meta(AbstractTemplateMixin.Meta):
-        db_table = 'django_template'
-        verbose_name = _('template')
-        verbose_name_plural = _('templates')
 
 
 def add_default_site(instance, **kwargs):


### PR DESCRIPTION
This reverts commit 46be8fc7489963ac6a05920f8e6de7af039a8266 and PR #150.

Splitting `Template` into a `AbstractTemplateMixin` and a concrete `Template` causes too many issues once we make the `Template.sites` model explicit, to the point that we would need to use something like swapper ([PyPI](https://pypi.org/project/swapper/), [GitHub](https://github.com/openwisp/django-swappable-models)) to make it work correctly.

Maybe at some point we might want to do that, but for now lets try to keep things simple.