### PR TITLE
Add project urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = ["django-appconf >= 0.4"]
 dynamic = ["version"]
 
 [project.urls]
-Homepage = "https://django-dbtemplates.readthedocs.io/"
+Documentation = "https://django-dbtemplates.readthedocs.io/"
+Changelog = "https://django-dbtemplates.readthedocs.io/en/latest/changelog.html"
+Source = "https://github.com/jazzband/django-dbtemplates"
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
Currently only docs are linked from PyPi, this adds a link to the source code too 

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
https://pypi.org/project/django-dbtemplates/

It would be also nice if we could get a release out so Python 3.12+ is supported