### PR TITLE
confirm Python 3.14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 6
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -10,9 +10,9 @@ v5.0 (unreleased)
 
 * Dropped support for Python 3.7 and Django < 4.2.
 
-* Added support for Python 3.11, 3.12, 3.13.
+* Added support for Python 3.11, 3.12, 3.13, 3.14.
 
-* Django 5.x support
+* Django 5.x and 6.0 support
 
 v4.0 (2022-09-3)
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
 ]
 requires-python = ">=3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ minversion = 4.0
 envlist =
     flake8
     py3{8,9,10,11,12}-dj42
-    py3{10,11,12}-dj{50}
-    py3{10,11,12,13}-dj{51,52}
-    py3{12,13}-dj{main}
+    py3{10,11,12,13,14}-dj52
+    py3{12,13,14}-dj60
+    py3{12,13,14}-djmain
     coverage
 
 [gh-actions]
@@ -17,6 +17,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 skipsdist = true
@@ -28,14 +29,14 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
+    py314: python3.14
 setenv =
     DJANGO_SETTINGS_MODULE = dbtemplates.test_settings
 deps =
     -r requirements/tests.txt
     dj42: Django>=4.2,<4.3
-    dj50: Django>=5.0,<5.1
-    dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
+    dj60: Django>=6.0,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =


### PR DESCRIPTION
Confirmed Python 3.14 and Django 6.0 support, removed non lts (and not supported anymore) Django versions