### PR TITLE
fix codemirror editor width

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-26.04
   tools:
-    python: "3.9"
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/dbtemplates/static/dbtemplates/css/editor.css
+++ b/dbtemplates/static/dbtemplates/css/editor.css
@@ -17,3 +17,6 @@
   color: #999;
 }
 
+.CodeMirror-wrapping {
+  width: 85%;
+}


### PR DESCRIPTION
Fixes the width of the editor and also adds a dummy example project so it's easier to test changes.

**Before**
<img width="1865" height="1064" alt="2026-01-29_14-56" src="https://github.com/user-attachments/assets/0d65c21f-b8d6-4ab3-96d6-fab8ada5d32b" />







**After**
<img width="1886" height="1022" alt="2026-01-29_14-55" src="https://github.com/user-attachments/assets/4c8aa392-de66-4af8-8c98-cda13925113a" />
