### PR TITLE
fix pre commit to work with Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]


### PR DESCRIPTION
pyupgrade seems to be broken with Python 3.14: https://results.pre-commit.ci/run/github/378788/1776631910.QbTYYRE7S7qLCRa9vCkEUA

bumping the version seems to fix the issue

```
➜  django-dbtemplates git:(fix-pre-commit) [?] uvx prek run --all-files
pyupgrade................................................................Passed
check for merge conflicts................................................Passed
check yaml...............................................................Passed
```